### PR TITLE
Lower-case boolean literals 'True' and 'False'

### DIFF
--- a/risks.007
+++ b/risks.007
@@ -488,7 +488,7 @@ func enter_room(n) {
 
     say(H25, option_quit, ". Quit");
 
-    my is_choice_valid = True;
+    my is_choice_valid = true;
 
     while(is_game_active != 0) {
         say(H25,"What do you want do? ");
@@ -497,7 +497,7 @@ func enter_room(n) {
         for(^scenes[n].metadata_number_of_options) -> i {
             my i_as_string = ~(i + 1);
             if(choice == i_as_string) {
-                is_choice_valid = True;
+                is_choice_valid = true;
                 seed = seed * 3;
 
                 if(scenes[n].options[i].room != 666) {
@@ -513,7 +513,7 @@ func enter_room(n) {
                 game_over();
             }
         }
-        if(is_choice_valid == False) {
+        if(!is_choice_valid) {
             say(H25,"Agent X, please consider using your intellect. Make an valid choice.");
             seed = seed * 3;
         }
@@ -546,9 +546,9 @@ func aside_function(special_scene) {
 
     say(H25,"CASH: ", agent.cash, "$");
 
-    my is_choice_valid = False;
+    my is_choice_valid = false;
 
-      while(is_choice_valid == False) {
+      while(!is_choice_valid) {
 
         agent.time_spent = agent.time_spent + 5;
 
@@ -593,7 +593,7 @@ func aside_function(special_scene) {
         }
 
       }
-      if(is_choice_valid == False) {
+      if(!is_choice_valid) {
         say(H25,"Agent X, please consider using your intellect. Make a valid choice.");
       }
     say(H25,"-------------------------------------------------------------------------------------------------------");


### PR DESCRIPTION
In https://github.com/masak/007/pull/451 the three literals `None`,
`True`, and `False` changed capitalization to `none`, `true`, and
`false`, respectively. This commit tracks that.

I took the chance to also replace a few `== False` comparisons with
boolean negations. There's a style rule in there somewhere &mdash; not
to compare directly against booleans in conditionals, instead
falling back on truthiness semantics. And yes, this is _despite_
the fact that writing it out as the direct comparison is actually
more exact &mdash; "vagueness is a virtue" in this case, it seems &mdash;
and also despite the fact in these two instances, the variables
compared are boolean variables, could be typed as such, and then
truthiness would come down to direct comparison; that is, there's
no semantic difference _at all_ between the two styles.  Still, I
find I instinctively want to change `== True` to just the lhs
boolean and `== False` to just its negation... direct comparisons
with booleans look redundant to me, on a fairly instinctual level.

I will try to keep this rule in mind as I pen the actual Style
Guide™, coming soon to a repository near you!

This tracking commit comes after 007 merged the lowercasing
change back in 2019-01-16; that is, three weeks lagging. Ideally,
there should be no such delay. I know the fix needed &mdash;
I need to set up some automated testing of the three known
modules in the 007 ecosystem (all belonging to @claes-magnus),
and then regularly run low-frequency tests against these. I just
haven't gotten around to setting that up, but it's still a good
idea.